### PR TITLE
fix: Corrige geração de e-mail fake para que utilize apenas letras minusculas

### DIFF
--- a/src/components/FakeDataGenerator.vue
+++ b/src/components/FakeDataGenerator.vue
@@ -86,7 +86,7 @@ function generate() {
       result.value = faker.person.fullName()
       break
     case 'email':
-      result.value = faker.internet.email()
+      result.value = faker.internet.email().toLowerCase()
       break
     case 'phone':
       result.value = faker.phone.number('(##) #####-####')


### PR DESCRIPTION
Implementei uma pequena melhoria para que o gerador de dados Fake gere apenas emails com letras minusculas, atualmente os dados vem com a primeira letra sempre maiuscula